### PR TITLE
Fix node removal

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -22,8 +22,10 @@ glam.parser = {
 		    	var i, len = mutation.removedNodes.length;
 		    	for (i = 0; i < len; i++) {
 		    		var node = mutation.removedNodes[i];
-		    		var viewer = glam.viewers[doc.id];
-			    	viewer.removeNode(node);
+					if (node.glam) {
+						var viewer = glam.viewers[doc.id];
+						viewer.removeNode(node);
+					}
 		    	}
 		    }
 		    else if (mutation.type == "attributes") {

--- a/src/parser.js
+++ b/src/parser.js
@@ -22,10 +22,10 @@ glam.parser = {
 		    	var i, len = mutation.removedNodes.length;
 		    	for (i = 0; i < len; i++) {
 		    		var node = mutation.removedNodes[i];
-					if (node.glam) {
-						var viewer = glam.viewers[doc.id];
-						viewer.removeNode(node);
-					}
+				if (node.glam) {
+					var viewer = glam.viewers[doc.id];
+					viewer.removeNode(node);
+				}
 		    	}
 		    }
 		    else if (mutation.type == "attributes") {


### PR DESCRIPTION
Fixes removal of glam non-existent node from Viewer.  Here's an example

``` html
<glam>
    <scene id='scene0'>
        <group y='-1' id='group0'>
            <cube id="texturedcube" x="1.5" y='2' z='-5' depth='.5' height='1.5' ></cube>
        </group>
    </scene>
    <scene id='scene1'>
        <group id="testGroup" x='-3' y='1' z='-5'>
            <cone id="cony" x='1' y='-.5' z='2' rz='90deg'></cone>
            <cylinder id="cylinder2" x='-2'></cylinder>
        </group>
    </scene>
</glam>
```

Say I want to move testGroup to scene0, but scene1 was never parsed by glam.

``` javascript
var scene = document.querySelector('#scene0');
var group = document.querySelector('#testGroup');
scene.appendChild(group);
```

This used to fail as it attempted to remove `testGroup.glam.obj` from the `Viewer` in  `glam.Viewer.prototype.removeNode` , where `glam` (and thus `obj`) is undefined as it was never added.
