### PR TITLE
Bower file for easier development

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,10 @@
     "shaders",
     "demos",
     "css",
-    "javascripts"
+    "javascripts",
+    "*.html",
+    "params.json",
+    "README.md",
+    "server"
   ]
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "glam",
-  "version": "0.1.0",
   "homepage": "https://github.com/tparisi/glam",
   "authors": [
     "Tony Parisi <tparisi@gmail.com>"

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,33 @@
+{
+  "name": "glam",
+  "version": "0.1.0",
+  "homepage": "https://github.com/tparisi/glam",
+  "authors": [
+    "Tony Parisi <tparisi@gmail.com>"
+  ],
+  "description": "glam (GL And Markup) is a declaritive language for creating 3D web content.",
+  "main": "build/glam.js",
+  "keywords": [
+    "WebGL",
+    "3D",
+    "WebVR"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "tests",
+    "images",
+    "models",
+    "utils",
+    "fonts",
+    "img",
+    "docs",
+    "src",
+    "sounds",
+    "examples",
+    "shaders",
+    "demos",
+    "css",
+    "javascripts"
+  ]
+}


### PR DESCRIPTION
A bower file makes it easier to use glam. Devs can start using glam quickly by running `bower install tparisi/glam` (or just `bower install glam`, if you decide to add it to the bower registry) and bower will fetch the GitHub repo automatically.

One big benefit is being able to ignore files that are unnecessary for development (the repo is quite large otherwise).

More info here: http://bower.io/docs/creating-packages/
