### PR TITLE
Update to three.js r71

### DIFF
--- a/libs/DotScreenRGBShader.js
+++ b/libs/DotScreenRGBShader.js
@@ -1,0 +1,70 @@
+/**
+ * @author alteredq / http://alteredqualia.com/
+ *
+ * Dot screen shader
+ * based on glfx.js sepia shader
+ * https://github.com/evanw/glfx.js
+ */
+
+THREE.DotScreenRGBShader = {
+
+    uniforms: {
+
+        "tDiffuse": { type: "t", value: null },
+        "tSize":    { type: "v2", value: new THREE.Vector2( 256, 256 ) },
+        "center":   { type: "v2", value: new THREE.Vector2( 0.5, 0.5 ) },
+        "angle":    { type: "f", value: 1.57 },
+        "scale":    { type: "f", value: 1.0 }
+
+    },
+
+    vertexShader: [
+
+        "varying vec2 vUv;",
+
+        "void main() {",
+
+            "vUv = uv;",
+            "gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );",
+
+        "}"
+
+    ].join("\n"),
+
+    fragmentShader: [
+
+        "uniform vec2 center;",
+        "uniform float angle;",
+        "uniform float scale;",
+        "uniform vec2 tSize;",
+
+        "uniform sampler2D tDiffuse;",
+
+        "varying vec2 vUv;",
+
+        "float pattern() {",
+
+            "float s = sin( angle ), c = cos( angle );",
+
+            "vec2 tex = vUv * tSize - center;",
+            "vec2 point = vec2( c * tex.x - s * tex.y, s * tex.x + c * tex.y ) * scale;",
+
+            "return ( sin( point.x ) * sin( point.y ) ) * 4.0;",
+
+        "}",
+
+        "void main() {",
+
+            "vec4 color = texture2D( tDiffuse, vUv );",
+
+            "float r = color.r * 10.0 - 5.0 + pattern();",
+            "float g = color.g * 10.0 - 5.0 + pattern();",
+            "float b = color.b * 10.0 - 5.0 + pattern();",
+
+            "gl_FragColor = vec4( r, g, b, color.a );",
+
+        "}"
+
+    ].join("\n")
+
+};

--- a/libs/ShaderParticleEngine.Release-0.7.9
+++ b/libs/ShaderParticleEngine.Release-0.7.9
@@ -1,0 +1,1 @@
+bower_components/ShaderParticleEngine

--- a/libs/bower.json
+++ b/libs/bower.json
@@ -1,0 +1,7 @@
+{
+  "name": "glam libs",
+  "dependencies": {
+    "ShaderParticleEngine": "squarefeet/ShaderParticleEngine#Release-0.7.9",
+    "three.js": "mrdoob/three.js#r71"
+  }
+}

--- a/libs/three.js.r71
+++ b/libs/three.js.r71
@@ -1,0 +1,1 @@
+bower_components/three.js

--- a/src/graphics/graphicsThreeJS.js
+++ b/src/graphics/graphicsThreeJS.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Main interface to the graphics and rendering subsystem
- * 
+ *
  * @author Tony Parisi
  */
 goog.require('glam.Graphics');
@@ -16,7 +16,7 @@ goog.inherits(glam.GraphicsThreeJS, glam.Graphics);
 glam.GraphicsThreeJS.prototype.initialize = function(param)
 {
 	param = param || {};
-	
+
 	// call all the setup functions
 	this.initOptions(param);
 	this.initPageElements(param);
@@ -37,7 +37,7 @@ glam.GraphicsThreeJS.prototype.focus = function()
 
 glam.GraphicsThreeJS.prototype.initOptions = function(param)
 {
-	this.displayStats = (param && param.displayStats) ? 
+	this.displayStats = (param && param.displayStats) ?
 			param.displayStats : glam.GraphicsThreeJS.default_display_stats;
 }
 
@@ -54,7 +54,7 @@ glam.GraphicsThreeJS.prototype.initPageElements = function(param)
    	}
 
     this.saved_cursor = this.container.style.cursor;
-    
+
     if (this.displayStats)
     {
     	if (window.Stats)
@@ -78,24 +78,24 @@ glam.GraphicsThreeJS.prototype.initScene = function()
 {
     var scene = new THREE.Scene();
 
-//    scene.add( new THREE.AmbientLight(0xffffff) ); //  0x505050 ) ); // 
-	
-    var camera = new THREE.PerspectiveCamera( 45, 
+//    scene.add( new THREE.AmbientLight(0xffffff) ); //  0x505050 ) ); //
+
+    var camera = new THREE.PerspectiveCamera( 45,
     		this.container.offsetWidth / this.container.offsetHeight, 1, 10000 );
     camera.position.copy(glam.Camera.DEFAULT_POSITION);
 
     scene.add(camera);
-    
+
     this.scene = scene;
 	this.camera = camera;
-	
+
 	this.backgroundLayer = {};
     var scene = new THREE.Scene();
-    var camera = new THREE.PerspectiveCamera( 45, 
+    var camera = new THREE.PerspectiveCamera( 45,
     		this.container.offsetWidth / this.container.offsetHeight, 0.01, 10000 );
-    camera.position.set( 0, 0, 10 );	
+    camera.position.set( 0, 0, 10 );
     scene.add(camera);
-    
+
     this.backgroundLayer.scene = scene;
     this.backgroundLayer.camera = camera;
 }
@@ -105,13 +105,13 @@ glam.GraphicsThreeJS.prototype.initRenderer = function(param)
 	var antialias = (param.antialias !== undefined) ? param.antialias : true;
 	var alpha = (param.alpha !== undefined) ? param.alpha : true;
 	//var devicePixelRatio = (param.devicePixelRatio !== undefined) ? param.devicePixelRatio : 1;
-	
+
     var renderer = // glam.Config.USE_WEBGL ?
-    	new THREE.WebGLRenderer( { antialias: antialias, 
+    	new THREE.WebGLRenderer( { antialias: antialias,
     		alpha: alpha,
     		/*devicePixelRatio : devicePixelRatio */ } ); // :
     	// new THREE.CanvasRenderer;
-    	
+
     renderer.sortObjects = false;
     renderer.setSize( this.container.offsetWidth, this.container.offsetHeight );
 
@@ -120,7 +120,7 @@ glam.GraphicsThreeJS.prototype.initRenderer = function(param)
     	renderer.domElement.style.backgroundColor = param.backgroundColor;
     	renderer.domElement.setAttribute('z-index', -1);
     }
-    
+
     this.container.appendChild( renderer.domElement );
 
     var projector = new THREE.Projector();
@@ -129,7 +129,7 @@ glam.GraphicsThreeJS.prototype.initRenderer = function(param)
     this.projector = projector;
 
     this.lastFrameTime = 0;
-    
+
     if (param.riftRender) {
     	this.riftCam = new THREE.VREffect(this.renderer, function(err) {
 			if (err) {
@@ -141,7 +141,7 @@ glam.GraphicsThreeJS.prototype.initRenderer = function(param)
     	this.cardboard = new THREE.StereoEffect(this.renderer);
     	this.cardboard.setSize( this.container.offsetWidth, this.container.offsetHeight );
     }
-    
+
     // Placeholder for effects composer
     this.composer = null;
 }
@@ -149,47 +149,47 @@ glam.GraphicsThreeJS.prototype.initRenderer = function(param)
 glam.GraphicsThreeJS.prototype.initMouse = function()
 {
 	var dom = this.renderer.domElement;
-	
+
 	var that = this;
-	dom.addEventListener( 'mousemove', 
+	dom.addEventListener( 'mousemove',
 			function(e) { that.onDocumentMouseMove(e); }, false );
-	dom.addEventListener( 'mousedown', 
+	dom.addEventListener( 'mousedown',
 			function(e) { that.onDocumentMouseDown(e); }, false );
-	dom.addEventListener( 'mouseup', 
-			function(e) { that.onDocumentMouseUp(e); }, false ); 
- 	dom.addEventListener( 'click', 
+	dom.addEventListener( 'mouseup',
+			function(e) { that.onDocumentMouseUp(e); }, false );
+ 	dom.addEventListener( 'click',
 			function(e) { that.onDocumentMouseClick(e); }, false );
-	dom.addEventListener( 'dblclick', 
+	dom.addEventListener( 'dblclick',
 			function(e) { that.onDocumentMouseDoubleClick(e); }, false );
 
-	dom.addEventListener( 'mousewheel', 
+	dom.addEventListener( 'mousewheel',
 			function(e) { that.onDocumentMouseScroll(e); }, false );
-	dom.addEventListener( 'DOMMouseScroll', 
+	dom.addEventListener( 'DOMMouseScroll',
 			function(e) { that.onDocumentMouseScroll(e); }, false );
-	
-	dom.addEventListener( 'touchstart', 
+
+	dom.addEventListener( 'touchstart',
 			function(e) { that.onDocumentTouchStart(e); }, false );
-	dom.addEventListener( 'touchmove', 
+	dom.addEventListener( 'touchmove',
 			function(e) { that.onDocumentTouchMove(e); }, false );
-	dom.addEventListener( 'touchend', 
+	dom.addEventListener( 'touchend',
 			function(e) { that.onDocumentTouchEnd(e); }, false );
 }
 
 glam.GraphicsThreeJS.prototype.initKeyboard = function()
 {
 	var dom = this.renderer.domElement;
-	
+
 	var that = this;
-	dom.addEventListener( 'keydown', 
+	dom.addEventListener( 'keydown',
 			function(e) { that.onKeyDown(e); }, false );
-	dom.addEventListener( 'keyup', 
+	dom.addEventListener( 'keyup',
 			function(e) { that.onKeyUp(e); }, false );
-	dom.addEventListener( 'keypress', 
+	dom.addEventListener( 'keypress',
 			function(e) { that.onKeyPress(e); }, false );
 
 	// so it can take focus
 	dom.setAttribute("tabindex", 1);
-    
+
 }
 
 glam.GraphicsThreeJS.prototype.addDomHandlers = function()
@@ -198,11 +198,11 @@ glam.GraphicsThreeJS.prototype.addDomHandlers = function()
 	window.addEventListener( 'resize', function(event) { that.onWindowResize(event); }, false );
 
 	setTimeout(function(event) { that.onWindowResize(event); }, 10);
-	
+
 	var fullScreenChange =
 		this.renderer.domElement.mozRequestFullScreen? 'mozfullscreenchange' : 'webkitfullscreenchange';
-	
-	document.addEventListener( fullScreenChange, 
+
+	document.addEventListener( fullScreenChange,
 			function(e) {that.onFullScreenChanged(e); }, false );
 
 }
@@ -210,38 +210,38 @@ glam.GraphicsThreeJS.prototype.addDomHandlers = function()
 glam.GraphicsThreeJS.prototype.objectFromMouse = function(event)
 {
 	var eltx = event.elementX, elty = event.elementY;
-	
+
 	// translate client coords into vp x,y
     var vpx = ( eltx / this.container.offsetWidth ) * 2 - 1;
     var vpy = - ( elty / this.container.offsetHeight ) * 2 + 1;
-    
+
     var vector = new THREE.Vector3( vpx, vpy, 0.5 );
 
-    this.projector.unprojectVector( vector, this.camera );
-	
+    vector.unproject( this.camera );
+
     var pos = new THREE.Vector3;
     pos = pos.applyMatrix4(this.camera.matrixWorld);
-	
+
     var raycaster = new THREE.Raycaster( pos, vector.sub( pos ).normalize() );
 
 	var intersects = raycaster.intersectObjects( this.scene.children, true );
-	
+
     if ( intersects.length > 0 ) {
     	var i = 0;
-    	while(i < intersects.length && (!intersects[i].object.visible || 
+    	while(i < intersects.length && (!intersects[i].object.visible ||
     			intersects[i].object.ignorePick))
     	{
     		i++;
     	}
-    	
+
     	var intersected = intersects[i];
-    	
+
     	if (i >= intersects.length)
     	{
         	return { object : null, point : null, normal : null };
     	}
-    	
-    	return (this.findObjectFromIntersected(intersected.object, intersected.point, intersected.face));        	    	                             
+
+    	return (this.findObjectFromIntersected(intersected.object, intersected.point, intersected.face));
     }
     else
     {
@@ -255,30 +255,30 @@ glam.GraphicsThreeJS.prototype.objectFromRay = function(hierarchy, origin, direc
 
     var objects = null;
     if (hierarchy) {
-    	objects = hierarchy.transform.object.children; 
+    	objects = hierarchy.transform.object.children;
     }
     else {
     	objects = this.scene.children;
     }
-    
+
 	var intersects = raycaster.intersectObjects( objects, true );
-	
+
     if ( intersects.length > 0 ) {
     	var i = 0;
-    	while(i < intersects.length && (!intersects[i].object.visible || 
+    	while(i < intersects.length && (!intersects[i].object.visible ||
     			intersects[i].object.ignoreCollision))
     	{
     		i++;
     	}
-    	
+
     	var intersected = intersects[i];
-    	
+
     	if (i >= intersects.length)
     	{
         	return { object : null, point : null, normal : null };
     	}
-    	
-    	return (this.findObjectFromIntersected(intersected.object, intersected.point, intersected.face));        	    	                             
+
+    	return (this.findObjectFromIntersected(intersected.object, intersected.point, intersected.face));
     }
     else
     {
@@ -315,36 +315,36 @@ glam.GraphicsThreeJS.prototype.nodeFromMouse = function(event)
 {
 	// Blerg, this is to support code outside the SB components & picker framework
 	// Returns a raw Three.js node
-	
+
 	// translate client coords into vp x,y
 	var eltx = event.elementX, elty = event.elementY;
-	
+
     var vpx = ( eltx / this.container.offsetWidth ) * 2 - 1;
     var vpy = - ( elty / this.container.offsetHeight ) * 2 + 1;
-    
+
     var vector = new THREE.Vector3( vpx, vpy, 0.5 );
 
-    this.projector.unprojectVector( vector, this.camera );
-	
+    vector.unproject( this.camera );
+
     var pos = new THREE.Vector3;
     pos = pos.applyMatrix4(this.camera.matrixWorld);
 
     var raycaster = new THREE.Raycaster( pos, vector.sub( pos ).normalize() );
 
 	var intersects = raycaster.intersectObjects( this.scene.children, true );
-	
+
     if ( intersects.length > 0 ) {
     	var i = 0;
     	while(!intersects[i].object.visible)
     	{
     		i++;
     	}
-    	
+
     	var intersected = intersects[i];
     	if (intersected)
     	{
-    		return { node : intersected.object, 
-    				 point : intersected.point, 
+    		return { node : intersected.object,
+    				 point : intersected.point,
     				 normal : intersected.face.normal
     				}
     	}
@@ -362,14 +362,14 @@ glam.GraphicsThreeJS.prototype.getObjectIntersection = function(x, y, object)
 	// Translate client coords into viewport x,y
 	var vpx = ( x / this.renderer.domElement.offsetWidth ) * 2 - 1;
 	var vpy = - ( y / this.renderer.domElement.offsetHeight ) * 2 + 1;
-	
+
     var vector = new THREE.Vector3( vpx, vpy, 0.5 );
 
-    this.projector.unprojectVector( vector, this.camera );
-	
+    vector.unproject( this.camera );
+
     var pos = new THREE.Vector3;
     pos = pos.applyMatrix4(this.camera.matrixWorld);
-	
+
     var raycaster = new THREE.Raycaster( pos, vector.sub( pos ).normalize() );
 
 	var intersects = raycaster.intersectObject( object, true );
@@ -383,14 +383,14 @@ glam.GraphicsThreeJS.prototype.getObjectIntersection = function(x, y, object)
 	}
 	else
 		return null;
-		
+
 }
 
 glam.GraphicsThreeJS.prototype.calcElementOffset = function(offset) {
 
 	offset.left = this.renderer.domElement.offsetLeft;
 	offset.top = this.renderer.domElement.offsetTop;
-	
+
 	var parent = this.renderer.domElement.offsetParent;
 	while(parent) {
 		offset.left += parent.offsetLeft;
@@ -402,48 +402,48 @@ glam.GraphicsThreeJS.prototype.calcElementOffset = function(offset) {
 glam.GraphicsThreeJS.prototype.onDocumentMouseMove = function(event)
 {
     event.preventDefault();
-    
+
 	var offset = {};
 	this.calcElementOffset(offset);
-	
+
 	var eltx = event.pageX - offset.left;
 	var elty = event.pageY - offset.top;
-	
-	var evt = { type : event.type, pageX : event.pageX, pageY : event.pageY, 
+
+	var evt = { type : event.type, pageX : event.pageX, pageY : event.pageY,
 	    	elementX : eltx, elementY : elty, button:event.button, altKey:event.altKey,
 	    	ctrlKey:event.ctrlKey, shiftKey:event.shiftKey };
-	
+
     glam.Mouse.instance.onMouseMove(evt);
-    
+
     if (glam.PickManager)
     {
     	glam.PickManager.handleMouseMove(evt);
     }
-    
+
     glam.Application.handleMouseMove(evt);
 }
 
 glam.GraphicsThreeJS.prototype.onDocumentMouseDown = function(event)
 {
     event.preventDefault();
-    
+
 	var offset = {};
 	this.calcElementOffset(offset);
-	
+
 	var eltx = event.pageX - offset.left;
 	var elty = event.pageY - offset.top;
-		
-	var evt = { type : event.type, pageX : event.pageX, pageY : event.pageY, 
+
+	var evt = { type : event.type, pageX : event.pageX, pageY : event.pageY,
 	    	elementX : eltx, elementY : elty, button:event.button, altKey:event.altKey,
 	    	ctrlKey:event.ctrlKey, shiftKey:event.shiftKey  };
-	
+
     glam.Mouse.instance.onMouseDown(evt);
-    
+
     if (glam.PickManager)
     {
     	glam.PickManager.handleMouseDown(evt);
     }
-    
+
     glam.Application.handleMouseDown(evt);
 }
 
@@ -453,20 +453,20 @@ glam.GraphicsThreeJS.prototype.onDocumentMouseUp = function(event)
 
 	var offset = {};
 	this.calcElementOffset(offset);
-	
+
 	var eltx = event.pageX - offset.left;
 	var elty = event.pageY - offset.top;
-	
-	var evt = { type : event.type, pageX : event.pageX, pageY : event.pageY, 
+
+	var evt = { type : event.type, pageX : event.pageX, pageY : event.pageY,
 	    	elementX : eltx, elementY : elty, button:event.button, altKey:event.altKey,
 	    	ctrlKey:event.ctrlKey, shiftKey:event.shiftKey  };
-    
+
     glam.Mouse.instance.onMouseUp(evt);
-    
+
     if (glam.PickManager)
     {
     	glam.PickManager.handleMouseUp(evt);
-    }	            
+    }
 
     glam.Application.handleMouseUp(evt);
 }
@@ -477,20 +477,20 @@ glam.GraphicsThreeJS.prototype.onDocumentMouseClick = function(event)
 
 	var offset = {};
 	this.calcElementOffset(offset);
-	
+
 	var eltx = event.pageX - offset.left;
 	var elty = event.pageY - offset.top;
-	
-	var evt = { type : event.type, pageX : event.pageX, pageY : event.pageY, 
+
+	var evt = { type : event.type, pageX : event.pageX, pageY : event.pageY,
 	    	elementX : eltx, elementY : elty, button:event.button, altKey:event.altKey,
 	    	ctrlKey:event.ctrlKey, shiftKey:event.shiftKey  };
-    
+
     glam.Mouse.instance.onMouseClick(evt);
-    
+
     if (glam.PickManager)
     {
     	glam.PickManager.handleMouseClick(evt);
-    }	            
+    }
 
     glam.Application.handleMouseClick(evt);
 }
@@ -501,23 +501,23 @@ glam.GraphicsThreeJS.prototype.onDocumentMouseDoubleClick = function(event)
 
 	var offset = {};
 	this.calcElementOffset(offset);
-	
+
 	var eltx = event.pageX - offset.left;
 	var elty = event.pageY - offset.top;
-	
+
 	var eltx = event.pageX - offset.left;
 	var elty = event.pageY - offset.top;
-	
-	var evt = { type : event.type, pageX : event.pageX, pageY : event.pageY, 
+
+	var evt = { type : event.type, pageX : event.pageX, pageY : event.pageY,
 	    	elementX : eltx, elementY : elty, button:event.button, altKey:event.altKey,
 	    	ctrlKey:event.ctrlKey, shiftKey:event.shiftKey  };
-    
+
     glam.Mouse.instance.onMouseDoubleClick(evt);
-    
+
     if (glam.PickManager)
     {
     	glam.PickManager.handleMouseDoubleClick(evt);
-    }	            
+    }
 
     glam.Application.handleMouseDoubleClick(evt);
 }
@@ -539,14 +539,14 @@ glam.GraphicsThreeJS.prototype.onDocumentMouseScroll = function(event)
 	}
 
 	var evt = { type : "mousescroll", delta : delta };
-    
+
     glam.Mouse.instance.onMouseScroll(evt);
 
     if (glam.PickManager)
     {
     	glam.PickManager.handleMouseScroll(evt);
     }
-    
+
     glam.Application.handleMouseScroll(evt);
 }
 
@@ -571,7 +571,7 @@ glam.GraphicsThreeJS.prototype.translateTouch = function(touch, offset) {
 glam.GraphicsThreeJS.prototype.onDocumentTouchStart = function(event)
 {
     event.preventDefault();
-    
+
 	var offset = {};
 	this.calcElementOffset(offset);
 
@@ -582,22 +582,22 @@ glam.GraphicsThreeJS.prototype.onDocumentTouchStart = function(event)
 	}
 
 	var evt = { type : event.type, touches : touches };
-	
+
     if (glam.PickManager)
     {
     	glam.PickManager.handleTouchStart(evt);
     }
-    
+
     glam.Application.handleTouchStart(evt);
 }
 
 glam.GraphicsThreeJS.prototype.onDocumentTouchMove = function(event)
 {
     event.preventDefault();
-    
+
 	var offset = {};
 	this.calcElementOffset(offset);
-	
+
 	var touches = [];
 	var i, len = event.touches.length;
 	for (i = 0; i < len; i++) {
@@ -611,12 +611,12 @@ glam.GraphicsThreeJS.prototype.onDocumentTouchMove = function(event)
 	}
 
 	var evt = { type : event.type, touches : touches, changedTouches : changedTouches };
-		    
+
     if (glam.PickManager)
     {
     	glam.PickManager.handleTouchMove(evt);
     }
-    
+
     glam.Application.handleTouchMove(evt);
 }
 
@@ -626,7 +626,7 @@ glam.GraphicsThreeJS.prototype.onDocumentTouchEnd = function(event)
 
 	var offset = {};
 	this.calcElementOffset(offset);
-	
+
 	var touches = [];
 	var i, len = event.touches.length;
 	for (i = 0; i < len; i++) {
@@ -640,11 +640,11 @@ glam.GraphicsThreeJS.prototype.onDocumentTouchEnd = function(event)
 	}
 
 	var evt = { type : event.type, touches : touches, changedTouches : changedTouches };
-    
+
     if (glam.PickManager)
     {
     	glam.PickManager.handleTouchEnd(evt);
-    }	            
+    }
 
     glam.Application.handleTouchEnd(evt);
 }
@@ -656,7 +656,7 @@ glam.GraphicsThreeJS.prototype.onKeyDown = function(event)
 	event.preventDefault();
 
     glam.Keyboard.instance.onKeyDown(event);
-    
+
 	glam.Application.handleKeyDown(event);
 }
 
@@ -666,17 +666,17 @@ glam.GraphicsThreeJS.prototype.onKeyUp = function(event)
 	event.preventDefault();
 
     glam.Keyboard.instance.onKeyUp(event);
-    
+
 	glam.Application.handleKeyUp(event);
 }
-	        
+
 glam.GraphicsThreeJS.prototype.onKeyPress = function(event)
 {
 	// N.B.: Chrome doesn't deliver keyPress if we don't bubble... keep an eye on this
 	event.preventDefault();
 
     glam.Keyboard.instance.onKeyPress(event);
-    
+
 	glam.Application.handleKeyPress(event);
 }
 
@@ -695,16 +695,16 @@ glam.GraphicsThreeJS.prototype.onWindowResize = function(event)
 	if (this.cardboard) {
 		this.cardboard.setSize(width, height);
 	}
-	
+
 	this.renderer.setSize(width, height);
-	
+
 	if (this.composer) {
 		this.composer.setSize(width, height);
 	}
-	
-	
+
+
 	if (glam.CameraManager && glam.CameraManager.handleWindowResize(this.container.offsetWidth, this.container.offsetHeight))
-	{		
+	{
 	}
 	else
 	{
@@ -714,7 +714,7 @@ glam.GraphicsThreeJS.prototype.onWindowResize = function(event)
 }
 
 glam.GraphicsThreeJS.prototype.onFullScreenChanged = function(event) {
-	
+
 	if ( !document.mozFullscreenElement && !document.webkitFullscreenElement ) {
 		this.fullscreen = false;
 	}
@@ -730,7 +730,7 @@ glam.GraphicsThreeJS.prototype.setCursor = function(cursor)
 {
 	if (!cursor)
 		cursor = this.saved_cursor;
-	
+
 	this.container.style.cursor = cursor;
 }
 
@@ -756,7 +756,7 @@ glam.GraphicsThreeJS.prototype.update = function()
 	else {
 		this.render();
 	}
-	
+
     if (this.stats)
     {
     	this.stats.update();
@@ -799,13 +799,13 @@ glam.GraphicsThreeJS.prototype.setFullScreen = function(enable)
 	if (this.riftCam) {
 
 		this.fullscreen = enable;
-		
+
 		this.riftCam.setFullScreen(enable);
 	}
 	else if (this.cardboard) {
 
 		var canvas = this.renderer.domElement;
-		
+
 		if (enable) {
 			if ( this.container.mozRequestFullScreen ) {
 				this.container.mozRequestFullScreen();
@@ -831,23 +831,23 @@ glam.GraphicsThreeJS.prototype.setCamera = function(camera) {
 }
 
 glam.GraphicsThreeJS.prototype.addEffect = function(effect) {
-	
+
 	if (!this.composer) {
 		this.composer = new glam.Composer();
 	}
-	
+
 	if (!this.effects) {
 		this.effects  = [];
 	}
-	
+
 	if (effect.isShaderEffect) {
 		for (var i = 0; i < this.effects.length; i++) {
 			var ef = this.effects[i];
 //			ef.pass.renderToScreen = false;
-		}	
+		}
 //		effect.pass.renderToScreen = true;
 	}
-	
+
 	this.effects.push(effect);
 	this.composer.addEffect(effect);
 }

--- a/src/input/viewpicker.js
+++ b/src/input/viewpicker.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Picker component - add one to get picking support on your object
- * 
+ *
  * @author Tony Parisi
  */
 
@@ -9,7 +9,7 @@ goog.require('glam.Component');
 
 glam.ViewPicker = function(param) {
 	param = param || {};
-	
+
     glam.Component.call(this, param);
 
     this.enabled = (param.enabled !== undefined) ? param.enabled : true;
@@ -51,7 +51,7 @@ glam.ViewPicker.prototype.update = function() {
 glam.ViewPicker.prototype.unprojectMouse = function() {
 
 	this.unprojectedMouse.copy(this.mouse);
-	this.projector.unprojectVector(this.unprojectedMouse, glam.Graphics.instance.camera);
+    this.unprojectedMouse.unproject(glam.Graphics.instance.camera);
 }
 
 glam.ViewPicker.prototype.checkForIntersections = function(position) {

--- a/src/particles/particleEmitter.js
+++ b/src/particles/particleEmitter.js
@@ -3,7 +3,7 @@ goog.require('glam.Component');
 
 glam.ParticleEmitter = function(param) {
 	this.param = param || {};
-	
+
 	glam.Component.call(this, param);
 
 	var size = this.param.size || glam.ParticleEmitter.DEFAULT_SIZE;
@@ -22,7 +22,7 @@ glam.ParticleEmitter = function(param) {
 
 	this._active = false;
 
-	this.object = new ShaderParticleEmitter({
+	this.object = new SPE.Emitter({
 		size: size,
         sizeEnd: sizeEnd,
         colorStart: colorStart,
@@ -37,7 +37,7 @@ glam.ParticleEmitter = function(param) {
         accelerationSpread: accelerationSpread,
         blending: blending,
       });
-	
+
     Object.defineProperties(this, {
         active: {
 	        get: function() {
@@ -64,7 +64,7 @@ glam.ParticleEmitter.prototype.update = function() {
 glam.ParticleEmitter.prototype.setActive = function(active) {
 
     this._active = active;
-    
+
     if (this._active) {
     	this.object.enable();
     }

--- a/src/particles/particleSystem.js
+++ b/src/particles/particleSystem.js
@@ -5,7 +5,7 @@ goog.require('glam.ParticleEmitter');
 glam.ParticleSystem = function(param) {
 
 	param = param || {};
-	
+
 	var obj = new glam.Object;
 
 	var texture = param.texture || null;
@@ -13,10 +13,10 @@ glam.ParticleSystem = function(param) {
 
 	var visual = null;
 	if (param.geometry) {
-		
+
 		var color = (param.color !== undefined) ? param.color : glam.ParticleSystem.DEFAULT_COLOR;
 		var material = new THREE.PointCloudMaterial({color:color, size:param.size, map:param.map,
-			transparent: (param.map !== null), 
+			transparent: (param.map !== null),
 		    depthWrite: false,
 			vertexColors: (param.geometry.colors.length > 0)});
 		var ps = new THREE.PointCloud(param.geometry, material);
@@ -24,26 +24,26 @@ glam.ParticleSystem = function(param) {
 
 		if (param.map)
 			ps.sortParticles = true;
-		
+
 	    visual = new glam.Visual({object:ps});
 	}
 	else {
-		
-		var particleGroup = new ShaderParticleGroup({
+
+		var particleGroup = new SPE.Group({
 	        texture: texture,
 	        maxAge: maxAge,
 	      });
-		    
+
 	    visual = new glam.Visual({object:particleGroup.mesh});
 	}
-	
+
     obj.addComponent(visual);
-    
+
 	param.particleGroup = particleGroup;
-	
+
 	var pScript = new glam.ParticleSystemScript(param);
 	obj.addComponent(pScript);
-	
+
 	return obj;
 }
 
@@ -52,9 +52,9 @@ glam.ParticleSystemScript = function(param) {
 	glam.Script.call(this, param);
 
 	this.particleGroup = param.particleGroup;
-	
+
 	this._active = true;
-	
+
     Object.defineProperties(this, {
         active: {
 	        get: function() {
@@ -77,17 +77,17 @@ glam.ParticleSystemScript.prototype.realize = function()
 }
 
 glam.ParticleSystemScript.prototype.initEmitters = function() {
-	
+
 	var emitters = this._object.getComponents(glam.ParticleEmitter);
-	
+
 	var i = 0, len = emitters.length;
-	
+
     for (i = 0; i < len; i++) {
     	var emitter = emitters[i];
     	this.particleGroup.addEmitter(emitter.object);
     	emitter.active = this._active;
     }
-    
+
     this.emitters = emitters;
 }
 
@@ -96,9 +96,9 @@ glam.ParticleSystemScript.prototype.setActive = function(active) {
 	var emitters = this.emitters;
 	if (!emitters)
 		return;
-	
+
 	var i = 0, len = emitters.length;
-	
+
     for (i = 0; i < len; i++) {
     	var emitter = emitters[i];
     	emitter.active = active;

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -1,0 +1,35 @@
+BUILDDIR=../build
+THREEDIR=../libs/three.js.r71
+THREEEXJSDIR="$THREEDIR/examples/js"
+STATS="$THREEEXJSDIR/libs/stats.min.js"
+SHADERPARTICLEENGINEDIR=../libs/ShaderParticleEngine.Release-0.7.9
+
+LOADERS="$THREEEXJSDIR/controls/VRControls.js \
+$THREEEXJSDIR/loaders/ColladaLoader.js \
+$THREEEXJSDIR/loaders/gltf/glTF-parser.js \
+$THREEEXJSDIR/loaders/gltf/glTFLoader.js \
+$THREEEXJSDIR/loaders/gltf/glTFLoaderUtils.js \
+$THREEEXJSDIR/loaders/gltf/glTFAnimation.js \
+$THREEEXJSDIR/postprocessing/EffectComposer.js \
+$THREEEXJSDIR/postprocessing/FilmPass.js \
+$THREEEXJSDIR/postprocessing/BloomPass.js \
+$THREEEXJSDIR/postprocessing/MaskPass.js \
+$THREEEXJSDIR/postprocessing/RenderPass.js \
+$THREEEXJSDIR/postprocessing/ShaderPass.js \
+$THREEEXJSDIR/renderers/Projector.js \
+$THREEEXJSDIR/effects/StereoEffect.js \
+$THREEEXJSDIR/effects/VREffect.js \
+$THREEEXJSDIR/shaders/ConvolutionShader.js \
+$THREEEXJSDIR/shaders/CopyShader.js \
+$THREEEXJSDIR/shaders/DotScreenShader.js \
+../libs/DotScreenRGBShader.js \
+$THREEEXJSDIR/shaders/FilmShader.js \
+$THREEEXJSDIR/shaders/FXAAShader.js \
+$THREEEXJSDIR/shaders/RGBShiftShader.js \
+$SHADERPARTICLEENGINEDIR/build/ShaderParticles.min.js"
+
+RAF=../libs/requestAnimationFrame/RequestAnimationFrame.js
+TWEEN=../libs/tween.js/tween.min.js
+NODEPS=../src/config/nodeps.js
+FONTS="../fonts/helvetiker_bold.typeface.js \
+../fonts/helvetiker_regular.typeface.js"

--- a/utils/compile-all.sh
+++ b/utils/compile-all.sh
@@ -1,4 +1,4 @@
-Echo "Compiling debug..."
+echo "Compiling debug..."
 ./compile-debug.sh
-Echo "Compiling min..."
+echo "Compiling min..."
 ./compile-min.sh

--- a/utils/compile-debug.sh
+++ b/utils/compile-debug.sh
@@ -1,38 +1,41 @@
-BUILDDIR=../build
+
+. ./common.sh
+
+THREE="$THREEDIR/build/three.js"
+LIBS="$THREE $STATS $LOADERS $TWEEN $RAF"
+
 TARGET="$BUILDDIR/glam-nodeps.js"
 OUTPUT="$BUILDDIR/glam.js"
-THREEDIR=../libs/three.js.r68
-THREE="$THREEDIR/three.js"
-STATS="$THREEDIR/stats.min.js"
-LOADERS="$THREEDIR/controls/VRControls.js \
-$THREEDIR/loaders/ColladaLoader.js \
-$THREEDIR/loaders/glTF/glTF-parser.js \
-$THREEDIR/loaders/glTF/glTFLoader.js \
-$THREEDIR/loaders/glTF/glTFLoaderUtils.js \
-$THREEDIR/loaders/glTF/glTFAnimation.js \
-$THREEDIR/postprocessing/EffectComposer.js \
-$THREEDIR/postprocessing/FilmPass.js \
-$THREEDIR/postprocessing/BloomPass.js \
-$THREEDIR/postprocessing/MaskPass.js \
-$THREEDIR/postprocessing/RenderPass.js \
-$THREEDIR/postprocessing/ShaderPass.js \
-$THREEDIR/renderers/StereoEffect.js \
-$THREEDIR/renderers/VREffect.js \
-$THREEDIR/shaders/ConvolutionShader.js \
-$THREEDIR/shaders/CopyShader.js \
-$THREEDIR/shaders/DotScreenShader.js \
-$THREEDIR/shaders/DotScreenRGBShader.js \
-$THREEDIR/shaders/FilmShader.js \
-$THREEDIR/shaders/FXAAShader.js \
-$THREEDIR/shaders/RGBShiftShader.js \
-$THREEDIR/ParticleEngine/ShaderParticles.min.js"
 
-RAF=../libs/requestAnimationFrame/RequestAnimationFrame.js
-TWEEN=../libs/tween.js/tween.min.js
-LIBS="$THREE $STATS $LOADERS $TWEEN $RAF"
-NODEPS=../src/config/nodeps.js
-FONTS="../fonts/helvetiker_bold.typeface.js \
-../fonts/helvetiker_regular.typeface.js"
+$CLOSURE_PATH/closure/bin/build/closurebuilder.py \
+    --root=$CLOSURE_PATH \
+    --root=../src/animations \
+    --root=../src/behaviors \
+    --root=../src/cameras \
+    --root=../src/controllers \
+    --root=../src/config \
+    --root=../src/core  \
+    --root=../src/dom  \
+    --root=../src/events \
+    --root=../src/graphics \
+    --root=../src/helpers \
+    --root=../src/input \
+    --root=../src/lights  \
+    --root=../src/loaders \
+    --root=../src/objects \
+    --root=../src/particles \
+    --root=../src/postprocessing \
+    --root=../src/prefabs \
+    --root=../src/scene \
+    --root=../src/scripts \
+    --root=../src/system \
+    --root=../src/time \
+    --root=../src/viewer \
+    --namespace="glam" \
+    --namespace="glam.Object" \
+    --namespace="glam.Modules" \
+    --output_mode=script \
+    --compiler_jar=compiler.jar \
+    --output_file=$TARGET
 
-$CLOSURE_PATH/closure/bin/build/closurebuilder.py --root=$CLOSURE_PATH  --root=../src/animations --root=../src/behaviors --root=../src/cameras --root=../src/controllers --root=../src/config --root=../src/core  --root=../src/dom  --root=../src/events --root=../src/graphics --root=../src/helpers --root=../src/input --root=../src/lights  --root=../src/loaders --root=../src/objects --root=../src/particles  --root=../src/postprocessing --root=../src/prefabs --root=../src/scene --root=../src/scripts --root=../src/system --root=../src/time --root=../src/viewer --namespace="glam" --namespace="glam.Object" --namespace="glam.Modules" --output_mode=script --compiler_jar=compiler.jar --output_file=$TARGET
 cat $LIBS $NODEPS $FONTS $TARGET > $OUTPUT

--- a/utils/compile-min.sh
+++ b/utils/compile-min.sh
@@ -1,40 +1,44 @@
-BUILDDIR=../build
+
+. ./common.sh
+
+THREE="$THREEDIR/build/three.min.js"
+LIBS="$THREE $STATS $LOADERS $TWEEN $RAF"
+
 TARGET="$BUILDDIR/glam-nodeps.min.js"
 OUTPUT="$BUILDDIR/glam.min.js"
-THREEDIR=../libs/three.js.r68
-THREE="$THREEDIR/three.min.js"
-STATS="$THREEDIR/stats.min.js"
-LOADERS="$THREEDIR/controls/VRControls.js \
-$THREEDIR/loaders/ColladaLoader.js \
-$THREEDIR/loaders/glTF/glTF-parser.js \
-$THREEDIR/loaders/glTF/glTFLoader.js \
-$THREEDIR/loaders/glTF/glTFLoaderUtils.js \
-$THREEDIR/loaders/glTF/glTFAnimation.js \
-$THREEDIR/postprocessing/EffectComposer.js \
-$THREEDIR/postprocessing/FilmPass.js \
-$THREEDIR/postprocessing/BloomPass.js \
-$THREEDIR/postprocessing/MaskPass.js \
-$THREEDIR/postprocessing/RenderPass.js \
-$THREEDIR/postprocessing/ShaderPass.js \
-$THREEDIR/renderers/StereoEffect.js \
-$THREEDIR/renderers/VREffect.js \
-$THREEDIR/shaders/ConvolutionShader.js \
-$THREEDIR/shaders/CopyShader.js \
-$THREEDIR/shaders/DotScreenShader.js \
-$THREEDIR/shaders/DotScreenRGBShader.js \
-$THREEDIR/shaders/FilmShader.js \
-$THREEDIR/shaders/FXAAShader.js \
-$THREEDIR/shaders/RGBShiftShader.js \
-$THREEDIR/ParticleEngine/ShaderParticles.min.js"
 
-
-RAF=../libs/requestAnimationFrame/RequestAnimationFrame.js
-TWEEN=../libs/tween.js/tween.min.js
-LIBS="$THREE $STATS $LOADERS $TWEEN $RAF"
-NODEPS=../src/config/nodeps.js
 FLAGS='--language_in=ECMASCRIPT5'
-FONTS="../fonts/helvetiker_bold.typeface.js \
-../fonts/helvetiker_regular.typeface.js"
 
-$CLOSURE_PATH/closure/bin/build/closurebuilder.py --root=$CLOSURE_PATH  --root=../src/animations --root=../src/behaviors --root=../src/cameras --root=../src/controllers --root=../src/config --root=../src/core  --root=../src/dom  --root=../src/events --root=../src/graphics --root=../src/helpers --root=../src/input --root=../src/lights  --root=../src/loaders --root=../src/objects --root=../src/particles --root=../src/postprocessing --root=../src/prefabs --root=../src/scene --root=../src/scripts --root=../src/system --root=../src/time --root=../src/viewer --namespace="glam" --namespace="glam.Object" --namespace="glam.Modules" --output_mode=compiled --compiler_flags=$FLAGS --compiler_jar=compiler.jar --output_file=$TARGET
+$CLOSURE_PATH/closure/bin/build/closurebuilder.py \
+    --root=$CLOSURE_PATH \
+    --root=../src/animations \
+    --root=../src/behaviors \
+    --root=../src/cameras \
+    --root=../src/controllers \
+    --root=../src/config \
+    --root=../src/core  \
+    --root=../src/dom  \
+    --root=../src/events \
+    --root=../src/graphics \
+    --root=../src/helpers \
+    --root=../src/input \
+    --root=../src/lights  \
+    --root=../src/loaders \
+    --root=../src/objects \
+    --root=../src/particles \
+    --root=../src/postprocessing \
+    --root=../src/prefabs \
+    --root=../src/scene \
+    --root=../src/scripts \
+    --root=../src/system \
+    --root=../src/time \
+    --root=../src/viewer \
+    --namespace="glam" \
+    --namespace="glam.Object" \
+    --namespace="glam.Modules" \
+    --output_mode=compiled \
+    --compiler_flags=$FLAGS \
+    --compiler_jar=compiler.jar \
+    --output_file=$TARGET
+
 cat $LIBS $NODEPS $FONTS $TARGET > $OUTPUT


### PR DESCRIPTION
The changes to `src/` files are pretty simple. I've refactored the build scripts a bit and also introduced a `bower.json` file to help maintain the three.js and ShaderParticleEngine libraries. Bower will install the libraries into a `bower_components/` directory under `libs/` and those directories are referenced by the symlinks I've added here.

There was a lot of trailing whitespace that my editor removed automatically. You can add `?w=1` to the pull request URL to have GitHub show you a diff with whitespace ignored.

I've tested the demos and examples and everything looks ok except for `glamcity.html`, which throws an error with the minified `glam.min.js`. It works with the debug `glam.js` but looks a bit strange (the building textures are much brighter for some reason). Hopefully you can look into that.

If you do decide to merge this, you'll have to complete the changes by adding the new libaries:
1. `cd` into `libs/`
2. Delete the existing `three.js.r68/` directory
3. Run `bower install` to fetch the latest libraries (as specified in `bower.json`)
